### PR TITLE
Bidder user sync configs

### DIFF
--- a/static/bidder-info/adf.yaml
+++ b/static/bidder-info/adf.yaml
@@ -12,3 +12,7 @@ capabilities:
       - banner
       - native
       - video
+userSync:
+  redirect:
+    url: "https://cm.adform.net/cookie?redirect_url={{.RedirectURL}}"
+    userMacro: "$UID"

--- a/static/bidder-info/adform.yaml
+++ b/static/bidder-info/adform.yaml
@@ -10,3 +10,7 @@ capabilities:
     mediaTypes:
       - banner
       - video
+userSync:
+  redirect:
+    url: "https://cm.adform.net/cookie?redirect_url={{.RedirectURL}}"
+    userMacro: "$UID"

--- a/static/bidder-info/adkernel.yaml
+++ b/static/bidder-info/adkernel.yaml
@@ -9,3 +9,7 @@ capabilities:
     mediaTypes:
       - banner
       - video
+userSync:
+  redirect:
+    url: "https://sync.adkernel.com/user-sync?t=image&gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&r={{.RedirectURL}}"
+    userMacro: "{UID}"

--- a/static/bidder-info/adkernelAdn.yaml
+++ b/static/bidder-info/adkernelAdn.yaml
@@ -9,3 +9,7 @@ capabilities:
     mediaTypes:
       - banner
       - video
+userSync:
+  redirect:
+    url: "https://tag.adkernel.com/syncr?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&r={{.RedirectURL}}"
+    userMacro: "{UID}"

--- a/static/bidder-info/adman.yaml
+++ b/static/bidder-info/adman.yaml
@@ -10,3 +10,7 @@ capabilities:
     mediaTypes:
       - banner
       - video
+userSync:
+  redirect:
+    url: "https://sync.admanmedia.com/pbs.gif?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&redir={{.RedirectURL}}"
+    userMacro: "[UID]"

--- a/static/bidder-info/admixer.yaml
+++ b/static/bidder-info/admixer.yaml
@@ -14,3 +14,7 @@ capabilities:
       - video
       - native
       - audio
+userSync:
+  redirect:
+    url: "https://inv-nets.admixer.net/adxcm.aspx?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&redir=1&rurl={{.RedirectURL}}"
+    userMacro: "$$visitor_cookie$$"

--- a/static/bidder-info/adpone.yaml
+++ b/static/bidder-info/adpone.yaml
@@ -8,3 +8,7 @@ capabilities:
   site:
     mediaTypes:
       - banner
+userSync:
+  redirect:
+    url: "https://usersync.adpone.com/csync?redir={{.RedirectURL}}"
+    userMacro: "{uid}"

--- a/static/bidder-info/advangelists.yaml
+++ b/static/bidder-info/advangelists.yaml
@@ -10,4 +10,8 @@ capabilities:
     mediaTypes:
     - banner
     - video
-   
+userSync:
+  iframe:
+    url: "https://nep.advangelists.com/xp/user-sync?acctid={aid}&&redirect={{.RedirectURL}}"
+    userMacro: "$UID"
+

--- a/static/bidder-info/adyoulike.yaml
+++ b/static/bidder-info/adyoulike.yaml
@@ -8,3 +8,7 @@ capabilities:
       - banner
       - video
       - native
+userSync:
+  redirect:
+    url: "http://visitor.omnitagjs.com/visitor/bsync?uid=19340f4f097d16f41f34fc0274981ca4&name=PrebidServer&gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&url={{.RedirectURL}}"
+    userMacro: "[BUYER_USERID]"

--- a/static/bidder-info/aja.yaml
+++ b/static/bidder-info/aja.yaml
@@ -10,4 +10,8 @@ capabilities:
     mediaTypes:
       - banner
       - video
+userSync:
+  redirect:
+    url: "https://ad.as.amanad.adtdp.com/v1/sync/ssp?ssp=4&gdpr={{.GDPR}}&us_privacy={{.USPrivacy}}&redir={{.RedirectURL}}"
+    userMacro: "%s"
 

--- a/static/bidder-info/amx.yaml
+++ b/static/bidder-info/amx.yaml
@@ -10,3 +10,7 @@ capabilities:
     mediaTypes:
       - banner
       - video
+userSync:
+  redirect:
+    url: "https://prebid.a-mo.net/cchain/0?gdpr={{.GDPR}}&us_privacy={{.USPrivacy}}&cb={{.RedirectURL}}"
+    userMacro: ""

--- a/static/bidder-info/appnexus.yaml
+++ b/static/bidder-info/appnexus.yaml
@@ -14,6 +14,6 @@ capabilities:
       - native
 userSync:
   key: "adnxs"
-    redirect:
-      url: "https://ib.adnxs.com/getuid?{{.RedirectURL}}"
-      userMacro: "$UID"
+  redirect:
+    url: "https://ib.adnxs.com/getuid?{{.RedirectURL}}"
+    userMacro: "$UID"

--- a/static/bidder-info/appnexus.yaml
+++ b/static/bidder-info/appnexus.yaml
@@ -12,3 +12,8 @@ capabilities:
       - banner
       - video
       - native
+userSync:
+  key: "adnxs"
+    redirect:
+      url: "https://ib.adnxs.com/getuid?{{.RedirectURL}}"
+      userMacro: "$UID"

--- a/static/bidder-info/avocet.yaml
+++ b/static/bidder-info/avocet.yaml
@@ -10,3 +10,7 @@ capabilities:
     mediaTypes:
       - banner
       - video
+userSync:
+  redirect:
+    url: "https://ads.avct.cloud/getuid?&gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&url={{.RedirectURL}}"
+    userMacro: "{{UUID}}"

--- a/static/bidder-info/beachfront.yaml
+++ b/static/bidder-info/beachfront.yaml
@@ -10,3 +10,7 @@ capabilities:
     mediaTypes:
       - banner
       - video
+userSync:
+  iframe:
+    url: "https://sync.bfmio.com/sync_s2s?gdpr={{.GDPR}}&us_privacy={{.USPrivacy}}&url={{.RedirectURL}}"
+    userMacro: "[io_cid]"

--- a/static/bidder-info/beintoo.yaml
+++ b/static/bidder-info/beintoo.yaml
@@ -5,3 +5,8 @@ capabilities:
   site:
     mediaTypes:
       - banner
+userSync:
+  key: "Beintoo"
+  iframe:
+    url: "https://ib.beintoo.com/um?ssp=pbs&gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&redirect={{.RedirectURL}}"
+    userMacro: "$UID"

--- a/static/bidder-info/between.yaml
+++ b/static/bidder-info/between.yaml
@@ -8,3 +8,7 @@ capabilities:
   app:
     mediaTypes:
       - banner
+userSync:
+  redirect:
+    url: "https://ads.betweendigital.com/match?bidder_id=pbs&gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&callback_url={{.RedirectURL}}"
+    userMacro: "${USER_ID}"

--- a/static/bidder-info/brightroll.yaml
+++ b/static/bidder-info/brightroll.yaml
@@ -10,3 +10,7 @@ capabilities:
     mediaTypes:
       - banner
       - video
+userSync:
+  redirect:
+    url: "https://pr-bh.ybp.yahoo.com/sync/appnexusprebidserver/?gdpr={{.GDPR}}&euconsent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&url={{.RedirectURL}}"
+    userMacro: "$UID"

--- a/static/bidder-info/colossus.yaml
+++ b/static/bidder-info/colossus.yaml
@@ -9,3 +9,7 @@ capabilities:
     mediaTypes:
       - banner
       - video
+userSync:
+  redirect:
+    url: "https://sync.colossusssp.com/pbs.gif?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&redir={{.RedirectURL}}"
+    userMacro: "[UID]"

--- a/static/bidder-info/connectad.yaml
+++ b/static/bidder-info/connectad.yaml
@@ -12,3 +12,4 @@ userSync:
   iframe:
     url: "https://cdn.connectad.io/connectmyusers.php?gdpr={{.GDPR}}&consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&cb={{.RedirectURL}}"
     userMacro: ""
+    # connectad appends the user id to end of the redirect url and does not utilize a macro

--- a/static/bidder-info/connectad.yaml
+++ b/static/bidder-info/connectad.yaml
@@ -8,3 +8,7 @@ capabilities:
   site:
     mediaTypes:
     - banner
+userSync:
+  iframe:
+    url: "https://cdn.connectad.io/connectmyusers.php?gdpr={{.GDPR}}&consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&cb={{.RedirectURL}}"
+    userMacro: ""

--- a/static/bidder-info/consumable.yaml
+++ b/static/bidder-info/consumable.yaml
@@ -12,3 +12,4 @@ userSync:
   redirect:
     url: "https://e.serverbid.com/udb/9969/match?gdpr={{.GDPR}}&euconsent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&redir={{.RedirectURL}}"
     userMacro: ""
+    # consumable appends the user id to end of the redirect url and does not utilize a macro

--- a/static/bidder-info/consumable.yaml
+++ b/static/bidder-info/consumable.yaml
@@ -8,3 +8,7 @@ capabilities:
   site:
     mediaTypes:
     - banner
+userSync:
+  redirect:
+    url: "https://e.serverbid.com/udb/9969/match?gdpr={{.GDPR}}&euconsent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&redir={{.RedirectURL}}"
+    userMacro: ""

--- a/static/bidder-info/conversant.yaml
+++ b/static/bidder-info/conversant.yaml
@@ -10,3 +10,7 @@ capabilities:
     mediaTypes:
       - banner
       - video
+userSync:
+  redirect:
+    url: "https://prebid-match.dotomi.com/match/bounce/current?version=1&networkId=72582&rurl={{.RedirectURL}}"
+    userMacro: ""

--- a/static/bidder-info/conversant.yaml
+++ b/static/bidder-info/conversant.yaml
@@ -14,3 +14,4 @@ userSync:
   redirect:
     url: "https://prebid-match.dotomi.com/match/bounce/current?version=1&networkId=72582&rurl={{.RedirectURL}}"
     userMacro: ""
+    # conversant appends the user id to end of the redirect url and does not utilize a macro

--- a/static/bidder-info/cpmstar.yaml
+++ b/static/bidder-info/cpmstar.yaml
@@ -9,3 +9,7 @@ capabilities:
     mediaTypes:
       - banner
       - video
+userSync:
+  redirect:
+    url: "https://server.cpmstar.com/usersync.aspx?gdpr={{.GDPR}}&consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&redirect={{.RedirectURL}}"
+    userMacro: "$UID"

--- a/static/bidder-info/datablocks.yaml
+++ b/static/bidder-info/datablocks.yaml
@@ -11,3 +11,7 @@ capabilities:
       - banner
       - native
       - video
+userSync:
+  redirect:
+    url: "https://sync.v5prebid.datablocks.net/s2ssync?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&r={{.RedirectURL}}"
+    userMacro: "${uid}"

--- a/static/bidder-info/deepintent.yaml
+++ b/static/bidder-info/deepintent.yaml
@@ -8,3 +8,7 @@ capabilities:
   site:
     mediaTypes:
       - banner
+userSync:
+  redirect:
+    url: "https://match.deepintent.com/usersync/136?id=unk&gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&redir={{.RedirectURL}}"
+    userMacro: "[UID]"

--- a/static/bidder-info/e_volution.yaml
+++ b/static/bidder-info/e_volution.yaml
@@ -12,3 +12,7 @@ capabilities:
       - banner
       - video
       - native
+userSync:
+  redirect:
+    url: "https://sync.e-volution.ai/pbserver?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&ccpa={{.USPrivacy}}&redirect={{.RedirectURL}}"
+    userMacro: "[UID]"

--- a/static/bidder-info/emx_digital.yaml
+++ b/static/bidder-info/emx_digital.yaml
@@ -10,3 +10,7 @@ capabilities:
     mediaTypes:
       - banner
       - video
+userSync:
+  iframe:
+    url: "https://cs.emxdgt.com/um?ssp=pbs&gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&redirect={{.RedirectURL}}"
+    userMacro: "$UID"

--- a/static/bidder-info/engagebdr.yaml
+++ b/static/bidder-info/engagebdr.yaml
@@ -7,3 +7,8 @@ capabilities:
     - banner
     - video
     - native
+userSync:
+  iframe:
+    url: "https://match.bnmla.com/usersync/s2s_sync?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&r={{.RedirectURL}}"
+    userMacro: "${UUID}"
+

--- a/static/bidder-info/eplanning.yaml
+++ b/static/bidder-info/eplanning.yaml
@@ -8,3 +8,7 @@ capabilities:
   site:
     mediaTypes:
       - banner
+userSync:
+  iframe:
+    url: "https://ads.us.e-planning.net/uspd/1/?du={{.RedirectURL}}"
+    userMacro: "$UID"

--- a/static/bidder-info/gamoshi.yaml
+++ b/static/bidder-info/gamoshi.yaml
@@ -10,3 +10,7 @@ capabilities:
     mediaTypes:
       - banner
       - video
+userSync:
+  redirect:
+    url: "https://rtb.gamoshi.io/user_sync_prebid?gdpr={{.GDPR}}&consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&rurl={{.RedirectURL}}"
+    userMacro: "[gusr]"

--- a/static/bidder-info/grid.yaml
+++ b/static/bidder-info/grid.yaml
@@ -10,3 +10,7 @@ capabilities:
     mediaTypes:
       - banner
       - video
+userSync:
+  redirect:
+    url: "https://x.bidswitch.net/check_uuid/{{.RedirectURL}}?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}"
+    userMacro: "${BSW_UUID}"

--- a/static/bidder-info/gumgum.yaml
+++ b/static/bidder-info/gumgum.yaml
@@ -6,3 +6,7 @@ capabilities:
     mediaTypes:
     - banner
     - video
+userSync:
+  iframe:
+    url: "https://rtb.gumgum.com/usync/prbds2s?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&r={{.RedirectURL}}"
+    userMacro: ""

--- a/static/bidder-info/gumgum.yaml
+++ b/static/bidder-info/gumgum.yaml
@@ -10,3 +10,4 @@ userSync:
   iframe:
     url: "https://rtb.gumgum.com/usync/prbds2s?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&r={{.RedirectURL}}"
     userMacro: ""
+    # gumgum appends the user id to end of the redirect url and does not utilize a macro

--- a/static/bidder-info/improvedigital.yaml
+++ b/static/bidder-info/improvedigital.yaml
@@ -12,3 +12,7 @@ capabilities:
       - banner
       - video
       - native
+userSync:
+  redirect:
+    url: "https://ad.360yield.com/server_match?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&r={{.RedirectURL}}"
+    userMacro: "{PUB_USER_ID}"

--- a/static/bidder-info/ix.yaml
+++ b/static/bidder-info/ix.yaml
@@ -18,3 +18,4 @@ userSync:
   redirect:
     url: "https://ssum.casalemedia.com/usermatchredir?s=194962&gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&cb={{.RedirectURL}}"
     userMacro: ""
+    # ix appends the user id to end of the redirect url and does not utilize a macro

--- a/static/bidder-info/ix.yaml
+++ b/static/bidder-info/ix.yaml
@@ -14,3 +14,7 @@ capabilities:
       - video
       - native
       - audio
+userSync:
+  redirect:
+    url: "https://ssum.casalemedia.com/usermatchredir?s=194962&gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&cb={{.RedirectURL}}"
+    userMacro: ""

--- a/static/bidder-info/jixie.yaml
+++ b/static/bidder-info/jixie.yaml
@@ -6,3 +6,7 @@ capabilities:
     mediaTypes:
       - banner
       - video
+userSync:
+  redirect:
+    url: "https://id.jixie.io/api/sync?pid=&gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&redirect={{.RedirectURL}}"
+    userMacro: "%%JXUID%%"

--- a/static/bidder-info/krushmedia.yaml
+++ b/static/bidder-info/krushmedia.yaml
@@ -11,3 +11,7 @@ capabilities:
       - banner
       - video
       - native
+userSync:
+  redirect:
+    url: "https://cs.krushmedia.com/4e4abdd5ecc661643458a730b1aa927d.gif?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&redir={{.RedirectURL}}"
+    userMacro: "[UID]"

--- a/static/bidder-info/lockerdome.yaml
+++ b/static/bidder-info/lockerdome.yaml
@@ -7,7 +7,10 @@ capabilities:
   site:
     mediaTypes:
       - banner
-userSync:
-  redirect:
-    url: "https://lockerdome.com/usync/prebidserver?pid="+cfg.Adapters["lockerdome"].PlatformID+"&gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&redirect={{.RedirectURL}}"
-    userMacro: "{{uid}}"
+# lockerdome requires a platform id for their user sync process. replace <<PlatformID>>
+# in the url below and uncomment the userSync section to enable.
+#
+#userSync:
+#  redirect:
+#    url: "https://lockerdome.com/usync/prebidserver?pid=<<PlatformID>>&gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&redirect={{.RedirectURL}}"
+#    userMacro: "{{uid}}"

--- a/static/bidder-info/lockerdome.yaml
+++ b/static/bidder-info/lockerdome.yaml
@@ -7,3 +7,7 @@ capabilities:
   site:
     mediaTypes:
       - banner
+userSync:
+  redirect:
+    url: "https://lockerdome.com/usync/prebidserver?pid="+cfg.Adapters["lockerdome"].PlatformID+"&gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&redirect={{.RedirectURL}}"
+    userMacro: "{{uid}}"

--- a/static/bidder-info/logicad.yaml
+++ b/static/bidder-info/logicad.yaml
@@ -7,4 +7,8 @@ capabilities:
   app:
     mediaTypes:
       - banner
+userSync:
+  redirect:
+    url: "https://cr-p31.ladsp.jp/cookiesender/31?r=true&gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&ru={{.RedirectURL}}"
+    userMacro: "$UID"
 

--- a/static/bidder-info/lunamedia.yaml
+++ b/static/bidder-info/lunamedia.yaml
@@ -10,4 +10,8 @@ capabilities:
     mediaTypes:
     - banner
     - video
-   
+userSync:
+  iframe:
+    url: "https://api.lunamedia.io/xp/user-sync?redirect={{.RedirectURL}}"
+    userMacro: "$UID"
+

--- a/static/bidder-info/marsmedia.yaml
+++ b/static/bidder-info/marsmedia.yaml
@@ -10,3 +10,7 @@ capabilities:
     mediaTypes:
       - banner
       - video
+userSync:
+  redirect:
+    url: "https://dmp.rtbsrv.com/dmp/profiles/cm?p_id=179&gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&redirect={{.RedirectURL}}"
+    userMacro: "${UUID}"

--- a/static/bidder-info/mgid.yaml
+++ b/static/bidder-info/mgid.yaml
@@ -10,3 +10,7 @@ capabilities:
     mediaTypes:
       - banner
       - native
+userSync:
+  redirect:
+    url: "https://cm.mgid.com/m?cdsp=363893&adu={{.RedirectURL}}"
+    userMacro: "{muidn}"

--- a/static/bidder-info/nanointeractive.yaml
+++ b/static/bidder-info/nanointeractive.yaml
@@ -8,3 +8,7 @@ capabilities:
   site:
     mediaTypes:
       - banner
+userSync:
+  redirect:
+    url: "https://ad.audiencemanager.de/hbs/cookie_sync?gdpr={{.GDPR}}&consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&redirectUri={{.RedirectURL}}"
+    userMacro: "$UID"

--- a/static/bidder-info/ninthdecimal.yaml
+++ b/static/bidder-info/ninthdecimal.yaml
@@ -10,4 +10,8 @@ capabilities:
     mediaTypes:
     - banner
     - video
-   
+userSync:
+  iframe:
+    url: "https://rtb.ninthdecimal.com/xp/user-sync?acctid={aid}&&redirect={{.RedirectURL}}"
+    userMacro: "$UID"
+

--- a/static/bidder-info/nobid.yaml
+++ b/static/bidder-info/nobid.yaml
@@ -10,3 +10,7 @@ capabilities:
     mediaTypes:
       - banner
       - video
+userSync:
+  redirect:
+    url: "https://ads.servenobid.com/getsync?tek=pbs&ver=1&gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&redirect={{.RedirectURL}}"
+    userMacro: "$UID"

--- a/static/bidder-info/onetag.yaml
+++ b/static/bidder-info/onetag.yaml
@@ -12,3 +12,7 @@ capabilities:
       - banner
       - video
       - native
+userSync:
+  iframe:
+    url: "https://onetag-sys.com/usync/?redir={{.RedirectURL}}"
+    userMacro: "${USER_TOKEN}"

--- a/static/bidder-info/openx.yaml
+++ b/static/bidder-info/openx.yaml
@@ -11,3 +11,7 @@ capabilities:
       - banner
       - video
 modifyingVastXmlAllowed: true
+userSync:
+  redirect:
+    url: "https://rtb.openx.net/sync/prebid?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&r={{.RedirectURL}}"
+    userMacro: "${UID}"

--- a/static/bidder-info/outbrain.yaml
+++ b/static/bidder-info/outbrain.yaml
@@ -10,3 +10,7 @@ capabilities:
     mediaTypes:
       - banner
       - native
+userSync:
+  redirect:
+    url: "https://prebidtest.zemanta.com/usersync/prebidtest?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&cb={{.RedirectURL}}"
+    userMacro: "__ZUID__"

--- a/static/bidder-info/pubmatic.yaml
+++ b/static/bidder-info/pubmatic.yaml
@@ -10,3 +10,7 @@ capabilities:
     mediaTypes:
       - banner
       - video
+userSync:
+  iframe:
+    url: "https://ads.pubmatic.com/AdServer/js/user_sync.html?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&predirect={{.RedirectURL}}"
+    userMacro: ""

--- a/static/bidder-info/pubmatic.yaml
+++ b/static/bidder-info/pubmatic.yaml
@@ -14,3 +14,4 @@ userSync:
   iframe:
     url: "https://ads.pubmatic.com/AdServer/js/user_sync.html?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&predirect={{.RedirectURL}}"
     userMacro: ""
+    # pubmatic appends the user id to end of the redirect url and does not utilize a macro

--- a/static/bidder-info/pulsepoint.yaml
+++ b/static/bidder-info/pulsepoint.yaml
@@ -14,3 +14,7 @@ capabilities:
       - video
       - audio
       - native
+userSync:
+  redirect:
+    url: "https://bh.contextweb.com/rtset?pid=561205&ev=1&rurl={{.RedirectURL}}"
+    userMacro: "%%VGUID%%"

--- a/static/bidder-info/rhythmone.yaml
+++ b/static/bidder-info/rhythmone.yaml
@@ -10,3 +10,7 @@ capabilities:
     mediaTypes:
       - banner
       - video
+userSync:
+  redirect:
+    url: "https://sync.1rx.io/usersync2/rmphb?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&redir={{.RedirectURL}}"
+    userMacro: "[RX_UUID]"

--- a/static/bidder-info/sharethrough.yaml
+++ b/static/bidder-info/sharethrough.yaml
@@ -10,3 +10,7 @@ capabilities:
     mediaTypes:
       - native
       - banner
+userSync:
+  redirect:
+    url: "https://match.sharethrough.com/FGMrCMMc/v1?redirectUri={{.RedirectURL}}"
+    userMacro: "$UID"

--- a/static/bidder-info/smartadserver.yaml
+++ b/static/bidder-info/smartadserver.yaml
@@ -10,3 +10,7 @@ capabilities:
     mediaTypes:
       - banner
       - video
+userSync:
+  redirect:
+    url: "https://ssbsync-global.smartadserver.com/api/sync?callerId=5&gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&redirectUri={{.RedirectURL}}"
+    userMacro: "[ssb_sync_pid]"

--- a/static/bidder-info/smartrtb.yaml
+++ b/static/bidder-info/smartrtb.yaml
@@ -9,3 +9,7 @@ capabilities:
     mediaTypes:
       - banner
       - video
+userSync:
+  redirect:
+    url: "https://market-global.smrtb.com/sync/all?nid=smartrtb&gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&rr={{.RedirectURL}}"
+    userMacro: "{XID}"

--- a/static/bidder-info/smartyads.yaml
+++ b/static/bidder-info/smartyads.yaml
@@ -11,4 +11,8 @@ capabilities:
       - banner
       - video
       - native
+userSync:
+  redirect:
+    url: "https://as.ck-ie.com/prebid.gif?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&redir={{.RedirectURL}}"
+    userMacro: "[UID]"
 

--- a/static/bidder-info/somoaudience.yaml
+++ b/static/bidder-info/somoaudience.yaml
@@ -11,3 +11,7 @@ capabilities:
       - banner
       - native
       - video
+userSync:
+  redirect:
+    url: "https://publisher-east.mobileadtrading.com/usersync?ru={{.RedirectURL}}"
+    userMacro: "${UID}"

--- a/static/bidder-info/sonobi.yaml
+++ b/static/bidder-info/sonobi.yaml
@@ -10,3 +10,7 @@ capabilities:
     mediaTypes:
       - banner
       - video
+userSync:
+  redirect:
+    url: "https://sync.go.sonobi.com/us.gif?loc={{.RedirectURL}}"
+    userMacro: "[UID]"

--- a/static/bidder-info/sovrn.yaml
+++ b/static/bidder-info/sovrn.yaml
@@ -8,3 +8,7 @@ capabilities:
   site:
     mediaTypes:
       - banner
+userSync:
+  redirect:
+    url: "https://ap.lijit.com/pixel?redir={{.RedirectURL}}"
+    userMacro: "$UID"

--- a/static/bidder-info/synacormedia.yaml
+++ b/static/bidder-info/synacormedia.yaml
@@ -9,3 +9,7 @@ capabilities:
     mediaTypes:
       - banner
       - video
+userSync:
+  iframe:
+    url: "https://sync.technoratimedia.com/services?srv=cs&pid=70&cb={{.RedirectURL}}"
+    userMacro: "[USER_ID]"

--- a/static/bidder-info/tappx.yaml
+++ b/static/bidder-info/tappx.yaml
@@ -10,3 +10,7 @@ capabilities:
     mediaTypes:
       - banner
       - video
+userSync:
+  iframe:
+    url: "https://ssp.api.tappx.com/cs/usersync.php?gdpr_optin={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&type=iframe&ruid={{.RedirectURL}}"
+    userMacro: "{{TPPXUID}}"

--- a/static/bidder-info/telaria.yaml
+++ b/static/bidder-info/telaria.yaml
@@ -8,3 +8,7 @@ capabilities:
   site:
     mediaTypes:
       - video
+userSync:
+  redirect:
+    url: "https://pbs.publishers.tremorhub.com/pubsync?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&redir={{.RedirectURL}}"
+    userMacro: "[tvid]"

--- a/static/bidder-info/triplelift.yaml
+++ b/static/bidder-info/triplelift.yaml
@@ -10,3 +10,7 @@ capabilities:
     mediaTypes:
       - banner
       - video
+userSync:
+  redirect:
+    url: "https://eb2.3lift.com/getuid?gdpr={{.GDPR}}&cmp_cs={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&redir={{.RedirectURL}}"
+    userMacro: "$UID"

--- a/static/bidder-info/triplelift_native.yaml
+++ b/static/bidder-info/triplelift_native.yaml
@@ -8,3 +8,8 @@ capabilities:
   site:
     mediaTypes:
       - native
+userSync:
+  key: "triplelift"
+  redirect:
+    url: "https://eb2.3lift.com/getuid?gdpr={{.GDPR}}&cmp_cs={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&redir={{.RedirectURL}}"
+    userMacro: "$UID"

--- a/static/bidder-info/trustx.yaml
+++ b/static/bidder-info/trustx.yaml
@@ -10,3 +10,7 @@ capabilities:
     mediaTypes:
       - banner
       - video
+userSync:
+  redirect:
+    url: "https://x.bidswitch.net/check_uuid/{{.RedirectURL}}?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}"
+    userMacro: "${BSW_UUID}"

--- a/static/bidder-info/ucfunnel.yaml
+++ b/static/bidder-info/ucfunnel.yaml
@@ -10,3 +10,7 @@ capabilities:
     mediaTypes:
       - banner
       - video
+userSync:
+  redirect:
+    url: "https://sync.aralego.com/idsync?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&usprivacy={{.USPrivacy}}&redirect={{.RedirectURL}}"
+    userMacro: "SspCookieUserId"

--- a/static/bidder-info/unruly.yaml
+++ b/static/bidder-info/unruly.yaml
@@ -8,3 +8,7 @@ capabilities:
   app:
     mediaTypes:
       - video
+userSync:
+  iframe:
+    url: "https://usermatch.targeting.unrulymedia.com/pbsync?gdpr={{.GDPR}}&consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&rurl={{.RedirectURL}}"
+    userMacro: "$UID"

--- a/static/bidder-info/valueimpression.yaml
+++ b/static/bidder-info/valueimpression.yaml
@@ -9,3 +9,7 @@ capabilities:
     mediaTypes:
       - banner
       - video
+userSync:
+  redirect:
+    url: "https://rtb.valueimpression.com/usersync?gdpr={{.GDPR}}&consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&redirect={{.RedirectURL}}"
+    userMacro: "$UID"

--- a/static/bidder-info/visx.yaml
+++ b/static/bidder-info/visx.yaml
@@ -8,3 +8,7 @@ capabilities:
   app:
     mediaTypes:
       - banner
+userSync:
+  redirect:
+    url: "https://t.visx.net/s2s_sync?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&redir={{.RedirectURL}}"
+    userMacro: "${UUID}"

--- a/static/bidder-info/yieldlab.yaml
+++ b/static/bidder-info/yieldlab.yaml
@@ -10,3 +10,7 @@ capabilities:
     mediaTypes:
       - banner
       - video
+userSync:
+  redirect:
+    url: "https://ad.yieldlab.net/mr?t=2&pid=9140838&gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&r={{.RedirectURL}}"
+    userMacro: "%%YL_UID%%"

--- a/static/bidder-info/yieldmo.yaml
+++ b/static/bidder-info/yieldmo.yaml
@@ -10,3 +10,7 @@ capabilities:
     mediaTypes:
     - banner
     - video
+userSync:
+  redirect:
+    url: "https://ads.yieldmo.com/pbsync?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&redirectUri={{.RedirectURL}}"
+    userMacro: "$UID"

--- a/static/bidder-info/yieldone.yaml
+++ b/static/bidder-info/yieldone.yaml
@@ -9,3 +9,7 @@ capabilities:
     mediaTypes:
       - banner
       - video
+userSync:
+  redirect:
+    url: "https://y.one.impact-ad.jp/hbs_cs?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&redirectUri={{.RedirectURL}}"
+    userMacro: "$UID"

--- a/static/bidder-info/zeroclickfraud.yaml
+++ b/static/bidder-info/zeroclickfraud.yaml
@@ -11,3 +11,7 @@ capabilities:
       - banner
       - native
       - video
+userSync:
+  iframe:
+    url: "https://s.0cf.io/sync?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&r={{.RedirectURL}}"
+    userMacro: "${uid}"


### PR DESCRIPTION
@SyntaxNode 
Added bidder user sync configs. 

I found some user syncers without userSync urls: 
```
"adocean", adapters.SyncTypeRedirect
"adtarget", adapters.SyncTypeIframe
"adtelligent", adapters.SyncTypeIframe
"adxcg", urlTemplate, adapters.SyncTypeRedir
"audienceNetwork", adapters.SyncTypeRedirect
"bmtm", adapters.SyncTypeRedirect
"criteo", adapters.SyncTypeRedirect
"dmx", adapters.SyncTypeRedirect
"gamma", adapters.SyncTypeIframe
"invibes", adapters.SyncTypeIframe
"mediafuse", adapters.SyncTypeIframe
"rtbhouse", urlTemplate, adapters.SyncTypeRe
"rubicon", adapters.SyncTypeRedirect
"verizonmedia", adapters.SyncTypeRedirect
"viewdeos", adapters.SyncTypeIframe
"vrtcal", adapters.SyncTypeRedirect
```

Also there are some configs where userMacro is empty:
"amx"
"connectad"
"consumable"
"conversant"
"gumgum"
"ix"
"pubmatic"

Please double check next configs, not sure about url:
"adnxs"
"grid"
"lockerdome" -> don;'t know about what url should be in this case
"trustx"